### PR TITLE
Remove feature(try_from) now that it's stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,12 @@ A Rust crate for translating keycodes based on Chrome's mapping of keys.
 
 `1fe838d`
 
-# How to Update Source File
+## How to Update Source File
 
 ```bash
 curl -sL 'https://chromium.googlesource.com/chromium/src/+/master/ui/events/keycodes/dom/keycode_converter_data.inc?format=TEXT' | base64 --decode > keycode_converter_data.inc
 ```
+
+## Supported Rust Versions
+
+Requires Rust 1.34.0 or newer due to use of [TryFrom](https://doc.rust-lang.org/std/convert/trait.TryFrom.html).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(try_from)]
-
 use bitflags::bitflags;
 use std::{collections::VecDeque, convert::TryFrom};
 


### PR DESCRIPTION
This PR allows the crate to build on stable Rust >= 1.34.0.