### PR TITLE
Allow parsing of KeyMappingCode from String

### DIFF
--- a/keycode/src/lib.rs
+++ b/keycode/src/lib.rs
@@ -63,6 +63,7 @@
 use arraydeque::ArrayDeque;
 use arrayvec::ArrayVec;
 
+use core::str::FromStr;
 use keycode_macro::parse_keycode_converter_data;
 
 parse_keycode_converter_data!();

--- a/keycode/tests/test.rs
+++ b/keycode/tests/test.rs
@@ -1,8 +1,21 @@
-use keycode::{KeyMap, KeyMapping, KeyMappingId, KeyModifiers, KeyState, KeyboardState};
+use keycode::{
+    KeyMap, KeyMapping, KeyMappingCode, KeyMappingId, KeyModifiers, KeyState, KeyboardState,
+};
+use std::str::FromStr;
 
 #[test]
 fn can_get_a_key_map() {
     let a = KeyMap::from(KeyMappingId::UsA);
+    assert_eq!(a.evdev, 30);
+    assert_eq!(a.usb, 4);
+
+    let key_map = KeyMap::from_key_mapping(KeyMapping::Evdev(a.evdev)).unwrap();
+    assert_eq!(key_map.usb, a.usb)
+}
+
+#[test]
+fn can_get_a_key_map_from_code_str() {
+    let a = KeyMap::from(KeyMappingCode::from_str("KeyA").unwrap());
     assert_eq!(a.evdev, 30);
     assert_eq!(a.usb, 4);
 

--- a/keycode_macro/src/generate.rs
+++ b/keycode_macro/src/generate.rs
@@ -1,4 +1,6 @@
 use crate::key_map::KeyMap;
+use core::result::Result;
+use core::str::FromStr;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use std::collections::HashSet;
@@ -214,6 +216,19 @@ pub fn generate(key_maps: HashSet<KeyMap>) -> TokenStream {
                     #(
                         KeyMappingCode::#codes => write!(f, stringify!(#codes)),
                     )*
+                }
+            }
+        }
+
+        impl FromStr for KeyMappingCode {
+            type Err = ();
+
+            fn from_str(code: &str) -> Result<KeyMappingCode, Self::Err> {
+                match code {
+                    #(
+                        stringify!(#codes) => Ok(KeyMappingCode::#codes),
+                    )*
+                    _ => {Err(())},
                 }
             }
         }

--- a/keycode_macro/src/lib.rs
+++ b/keycode_macro/src/lib.rs
@@ -5,9 +5,9 @@ mod key_map;
 mod parse;
 
 use self::{generate::*, parse::*};
+use core::str::FromStr;
 use proc_macro::TokenStream;
 use quote::quote;
-use std::str::FromStr;
 
 #[proc_macro]
 pub fn parse_keycode_converter_data(_input: TokenStream) -> TokenStream {

--- a/keycode_macro/tests/test.rs
+++ b/keycode_macro/tests/test.rs
@@ -1,3 +1,4 @@
+use core::str::FromStr;
 use keycode_macro::parse_keycode_converter_data;
 
 parse_keycode_converter_data!();


### PR DESCRIPTION
This PR adds the reverse mapping from String -> KeyMappingCode

This can be used to get the x11,evdev,win,mac representation from a browser representation (ie when implementing an API of some kind)